### PR TITLE
fix exception when org document has empty section.

### DIFF
--- a/src/extended/hash.lisp
+++ b/src/extended/hash.lisp
@@ -110,6 +110,11 @@
   (hash-table-count (slot-value *hash-cache* 'hash->node)))
 
 (defmethod hash-of :around ((o org-node))
+  ;; This mechanism will raise exception with conflicted hash.
+  ;; A better mechanism should be provided.
+  #+org-no-hash
+  (call-next-method)
+  #-org-no-hash
   (let ((cache *hash-cache*))
     (or (when-let ((cres (gethash o (slot-value cache 'node->hash))))
           (when *debug-hash-hits*

--- a/src/present.lisp
+++ b/src/present.lisp
@@ -43,7 +43,8 @@
     (format s "#+TITLE: ~A~%" title)
     (when-let ((properties (properties-of o)))
       (org-present-properties properties *present-depth* s))
-    (org-present kind section s)
+    (when section
+      (org-present kind section s))
     (let ((*presented-nodes* (make-hash-table :test 'eq)))
       (mark-node-presented o)
       (dolist (c (node.out o))
@@ -70,7 +71,8 @@
             status priority title tags)
     (when-let ((properties (properties-of o)))
       (org-present-properties properties *present-depth* s))
-    (org-present :flat section s)
+    (when section
+      (org-present :flat section s))
     (dolist (c (node.out o))
       (let ((*present-depth* (+ *present-depth-increment* *present-depth*)))
         (unless (node-presented-p c)

--- a/src/raw/utils.lisp
+++ b/src/raw/utils.lisp
@@ -10,9 +10,27 @@
             (collect elt into no))
         (finally (return (values yes no)))))
 
+(defmacro dotree ((name tree &optional ret-val) &body body)
+  "Evaluate BODY with NAME bound to every element in TREE. Return RET-VAL."
+  (with-unique-names (traverser list list-element)
+    `(progn
+       (labels ((,traverser (,list)
+                  (dolist (,list-element ,list)
+                    (if (consp ,list-element)
+                        (,traverser ,list-element)
+                        (let ((,name ,list-element))
+                          ,@body)))))
+         (,traverser ,tree)
+         ,ret-val))))
+
 ;; from pergamum
 (defun strconcat (xs)
-  (apply #'concatenate 'string xs))
+  (let ((*print-pretty* nil)
+        (*print-circle* nil))
+    (with-output-to-string (stream)
+      (dotree (str xs)
+        (when str
+          (princ str stream))))))
 
 ;; from pergamum
 (defun strconcat* (&rest xs)


### PR DESCRIPTION
1. some node has the same hash in my org file,so add a mechanism to disable the hash mechanism.
2. some document has empty section slot of org-document, add careful check for them.
