### PR TITLE
Instantiate org-drawer instead of org-basic-drawer.

### DIFF
--- a/src/dress.lisp
+++ b/src/dress.lisp
@@ -30,7 +30,7 @@
           ((:block :dynamic-block)
            (make-instance 'org-block        :name name :children (children-of (org-dress-section contents)) :parameters parameters))
           (:basic-drawer
-           (make-instance 'org-basic-drawer :name name :children (children-of (org-dress-section contents))))
+           (make-instance 'org-drawer :name name :children (children-of (org-dress-section contents))))
           (:property-drawer
            (make-instance 'org-properties              :children (mapcar #'org-dress-property contents)))
           ((:keyword :attribute)

--- a/src/present.lisp
+++ b/src/present.lisp
@@ -17,7 +17,7 @@
 
 ;;;
 ;;; Methods
-(defvar *present-depth*)
+(defvar *present-depth* 0)
 (defvar *present-depth-increment*)
 (defvar *presented-nodes*)
 


### PR DESCRIPTION
This replaces the non-existent `org-basic-drawer` class name with the existing `org-drawer`.

Backstory: I tried to parse a file with drawers and a debugger shouted this at me:
```
There is no class named CL-ORG-MODE::ORG-BASIC-DRAWER.
   [Condition of type SB-PCL:CLASS-NOT-FOUND-ERROR]
```

`org-basic-drawer` is not mentioned anywhere but in the patched piece of code and in `doc/raw-parser.org`, so no hurt in replacing it with an existing class. @deepfire, was it a plan for future to subclass `org-basic-drawer` from `org-drawer`?